### PR TITLE
made a version of CodeFormatter for Octokit

### DIFF
--- a/package.cmd
+++ b/package.cmd
@@ -1,0 +1,4 @@
+CALL .\build /p:Configuration=Release
+
+SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
+%CACHED_NUGET% pack src\nuget\Octokit.CodeFormatter.nuspec

--- a/package.cmd
+++ b/package.cmd
@@ -1,4 +1,4 @@
 CALL .\build /p:Configuration=Release
 
 SET CACHED_NUGET=%LocalAppData%\NuGet\NuGet.exe
-%CACHED_NUGET% pack src\nuget\Octokit.CodeFormatter.nuspec
+%CACHED_NUGET% pack src\nuget\Octokit.CodeFormatter.nuspec -NoPackageAnalysis

--- a/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/FormattingEngineImplementation.cs
@@ -103,6 +103,7 @@ namespace Microsoft.DotNet.CodeFormatting
             where TRule : IFormattingRule
         {
             return rules
+                .Where(r => !r.Metadata.Skip)
                 .OrderBy(r => r.Metadata.Order)
                 .Where(r => r.Metadata.FormattingLevel <= FormattingLevel)
                 .Select(r => r.Value)

--- a/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/IRuleMetadata.cs
@@ -12,5 +12,8 @@ namespace Microsoft.DotNet.CodeFormatting
 
         [DefaultValue(FormattingLevel.Simple)]
         FormattingLevel FormattingLevel { get; }
+
+        [DefaultValue(false)]
+        bool Skip { get; }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/RuleAttribute.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.CodeFormatting
 
         [DefaultValue(FormattingLevel.Simple)]
         public FormattingLevel FormattingLevel { get; set; }
+
+        [DefaultValue(false)]
+        public bool Skip { get; set; }
     }
 
     [MetadataAttribute]
@@ -43,6 +46,9 @@ namespace Microsoft.DotNet.CodeFormatting
 
         [DefaultValue(FormattingLevel.Simple)]
         public FormattingLevel FormattingLevel { get; set; }
+
+        [DefaultValue(false)]
+        public bool Skip { get; set; }
     }
 
     [MetadataAttribute]
@@ -60,5 +66,8 @@ namespace Microsoft.DotNet.CodeFormatting
 
         [DefaultValue(FormattingLevel.Simple)]
         public FormattingLevel FormattingLevel { get; set; }
+
+        [DefaultValue(false)]
+        public bool Skip { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/ExplicitVisibilityRule.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [LocalSemanticRule(LocalSemanticRuleOrder.ExplicitVisibilityRule)]
+    [LocalSemanticRule(LocalSemanticRuleOrder.ExplicitVisibilityRule, Skip = true)]
     internal sealed partial class ExplicitVisibilityRule : ILocalSemanticFormattingRule
     {
         public bool SupportsLanguage(string languageName)

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/NewLineAboveRule.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.CodeFormatting.Rules
     /// <summary>
     /// Ensure there is a blank line above the first using and namespace in the file. 
     /// </summary>
-    [SyntaxRule(SyntaxRuleOrder.NewLineAboveFormattingRule)]
+    [SyntaxRule(SyntaxRuleOrder.NewLineAboveFormattingRule, Skip = true)]
     internal sealed class NewLineAboveRule : CSharpOnlyFormattingRule, ISyntaxFormattingRule
     {
         public SyntaxNode Process(SyntaxNode syntaxRoot, string languageName)

--- a/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
+++ b/src/Microsoft.DotNet.CodeFormatting/Rules/PrivateFieldNamingRule.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Rename;
 
 namespace Microsoft.DotNet.CodeFormatting.Rules
 {
-    [GlobalSemanticRule(GlobalSemanticRuleOrder.PrivateFieldNamingRule)]
+    [GlobalSemanticRule(GlobalSemanticRuleOrder.PrivateFieldNamingRule, Skip = true)]
     internal partial class PrivateFieldNamingRule : IGlobalSemanticFormattingRule
     {
         #region CommonRule

--- a/src/nuget/Octokit.CodeFormatter.nuspec
+++ b/src/nuget/Octokit.CodeFormatter.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Octokit.CodeFormatter</id>
+    <version>1.0.0-preview</version>
+    <title>Octokit's CodeFormatter</title>
+    <authors>Brendan Forster</authors>
+    <owners>Microsoft</owners>
+    <description>A fork of the CodeFormatter tool which enforces a subset of the coding guidelines.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+      <dependency id="Microsoft.CodeAnalysis" version="1.0.0-beta1-20141031-01" />
+      <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" />
+      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" />
+      <dependency id="Microsoft.Composition" version="1.0.0-beta1-20141031-01" />
+      <dependency id="System.Reflection.Metadata" version="1.0.0-beta1-20141031-01" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\bin\CodeFormatter.exe" target="lib\net45" />
+    <file src="..\..\bin\Microsoft.DotNet.CodeFormatting.dll" target="lib\net45" />
+    <file src="..\..\bin\CodeFormatter\Release\CopyrightHeader.md" target="lib\net45" />
+    <file src="..\..\bin\CodeFormatter\Release\IllegalHeaders.md" target="lib\net45" />
+    <file src="..\..\bin\MSTestNamespaces.txt" target="lib\net45" />
+  </files>
+</package>

--- a/src/nuget/Octokit.CodeFormatter.nuspec
+++ b/src/nuget/Octokit.CodeFormatter.nuspec
@@ -8,19 +8,35 @@
     <owners>Microsoft</owners>
     <description>A fork of the CodeFormatter tool which enforces a subset of the coding guidelines.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
-    <dependencies>
-      <dependency id="Microsoft.CodeAnalysis" version="1.0.0-beta1-20141031-01" />
-      <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" />
-      <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" />
-      <dependency id="Microsoft.Composition" version="1.0.0-beta1-20141031-01" />
-      <dependency id="System.Reflection.Metadata" version="1.0.0-beta1-20141031-01" />
-    </dependencies>
   </metadata>
   <files>
-    <file src="..\..\bin\CodeFormatter.exe" target="lib\net45" />
-    <file src="..\..\bin\Microsoft.DotNet.CodeFormatting.dll" target="lib\net45" />
-    <file src="..\..\bin\CodeFormatter\Release\CopyrightHeader.md" target="lib\net45" />
-    <file src="..\..\bin\CodeFormatter\Release\IllegalHeaders.md" target="lib\net45" />
-    <file src="..\..\bin\MSTestNamespaces.txt" target="lib\net45" />
+    <file src="..\..\bin\CodeFormatter.exe" target="tools" />
+    <file src="..\..\bin\CodeFormatter\Release\CopyrightHeader.md" target="tools" />
+    <file src="..\..\bin\CodeFormatter\Release\IllegalHeaders.md" target="tools" />
+    <file src="..\..\bin\Microsoft.DotNet.CodeFormatting.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.CSharp.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.CSharp.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.CSharp.Workspaces.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.VisualBasic.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.Workspaces.Desktop.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.CodeAnalysis.Workspaces.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.DotNet.CodeFormatting.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.DotNet.CodeFormatting.Tests.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.DotNet.DeadRegionAnalysis.dll" target="tools" />
+    <file src="..\..\bin\Microsoft.DotNet.DeadRegionAnalysis.Tests.dll" target="tools" />
+    <file src="..\..\bin\System.Collections.Immutable.dll" target="tools" />
+    <file src="..\..\bin\System.Composition.AttributedModel.dll" target="tools" />
+    <file src="..\..\bin\System.Composition.Convention.dll" target="tools" />
+    <file src="..\..\bin\System.Composition.Hosting.dll" target="tools" />
+    <file src="..\..\bin\System.Composition.Runtime.dll" target="tools" />
+    <file src="..\..\bin\System.Composition.TypedParts.dll" target="tools" />
+    <file src="..\..\bin\System.Reflection.Metadata.dll" target="tools" />
+    <file src="..\..\bin\MSTestNamespaces.txt" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
I originally had plans to make this resolvable at runtime, but after fighting with (against?) MEF and how it resolves things, I got lazy and switched over to something simpler.

This is the changes, and this is the package you can download and play with yourself: https://www.nuget.org/packages/Octokit.CodeFormatter/1.0.0-preview
